### PR TITLE
[Oztechan/TraceFit#292] Point Project Automations at Oztechan Apps (#13) with milestone workflow

### DIFF
--- a/.github/workflows/project.yml
+++ b/.github/workflows/project.yml
@@ -14,7 +14,7 @@ on:
 
 jobs:
   ProjectAutomations:
-    uses: Oztechan/Global/.github/workflows/reusable-project.yml@b4f70067782bc72102bf785bca1f519aa92e11cd
+    uses: Oztechan/Global/.github/workflows/reusable-project.yml@17e6f5436e23d9f5ded36c820801cdac40fd99cf
     with:
-      project_id: 6
+      project_id: 13
     secrets: inherit


### PR DESCRIPTION
Points this repo's Project Automations at the consolidated **Oztechan Apps** project (#13) and adopts the milestone-based reusable workflow (Oztechan/Global#219).

- `project_id: 13`
- Bumps the reusable-project.yml Global pin to the new develop SHA (native milestones)
- Drops the removed `NEXT_VERSION` secret usage

Resolves Oztechan/TraceFit#292