### PR TITLE
[Oztechan/TraceFit#299] Enable parallel Gradle sync

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -21,3 +21,6 @@ kotlin.incremental.native=true
 org.jetbrains.compose.experimental.uikit.enabled=true
 # KMP
 kotlin.incremental.multiplatform=true
+
+# Enabled parallel sync for Gradle 9.4+
+org.gradle.tooling.parallel=true


### PR DESCRIPTION
Enables parallel Gradle model building during IDE sync (Gradle 9.4+), speeding up sync for this multi-module project.

Closes #299